### PR TITLE
Enhance key and value type validation in put method with logging

### DIFF
--- a/MemDB.py
+++ b/MemDB.py
@@ -9,12 +9,22 @@ class inMemoryDB:
         self.expiration_thread = Thread(target=self._delete_expired, daemon=True)
         self.expiration_thread.start()
 
+        self.key_data_type = str  # Default key type
+        self.value_data_type = str  # Default value type
+
         self.logger = logger(self.__class__.__name__)
         self.logger.log("Initialized in-memory database")
 
     # Store a value with a key and an optional expiration time in days
     # If expiration_time is None, it defaults to 7 seconds
     def put(self, key, value, expiration_time):
+        if not isinstance(key, self.key_data_type):
+            self.logger.log(f"Invalid key type: {type(key)}. Must be {self.key_data_type.__name__}.")
+            raise TypeError(f"Key must be of type {self.key_data_type.__name__}")
+        if not isinstance(value, self.value_data_type):
+            self.logger.log(f"Invalid value type: {type(value)}. Must be {self.value_data_type.__name__}.")
+            raise TypeError(f"Value must be of type {self.value_data_type.__name__}")
+        
         with self.lock:  # Ensure thread safety when modifying the data
             expiration_time = self._convert_expiration_time_parameter(expiration_time)
             self.data[key] = { "value" : value, "expiration_time": expiration_time }


### PR DESCRIPTION
This pull request introduces type validation for keys and values in the `MemDB` class, ensuring that they conform to specified default types (`str`). It also adds logging for type errors and raises exceptions when the types are invalid.

Enhancements to type validation and logging:

* [`MemDB.py`](diffhunk://#diff-867cc4cbbc3778839cf30cfcd32789aa5f8213606cf079c483903ac527d438a4R12-R27): Added `key_data_type` and `value_data_type` attributes to define default types for keys and values (`str`).
* [`MemDB.py`](diffhunk://#diff-867cc4cbbc3778839cf30cfcd32789aa5f8213606cf079c483903ac527d438a4R12-R27): Updated the `put` method to validate the types of `key` and `value` against the defined `key_data_type` and `value_data_type`. Logs type errors and raises `TypeError` if the types are invalid.